### PR TITLE
Add undo button. Fixes #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "eslintConfig": {
     "env": {
       "browser": true
+    },
+    "parserOptions": {
+      "ecmaVersion": "latest",
+      "sourceType": "module"
     }
   },
   "devDependencies": {

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -18,6 +18,7 @@ const $selection = document.getElementById('selection')
 const $share = document.getElementById('share')
 const $statistics = document.getElementById('statistics')
 const $swaps = document.getElementById('swaps')
+const $undo = document.getElementById('undo')
 const $width = document.getElementById('width')
 const $words = document.getElementById('words')
 
@@ -53,6 +54,7 @@ export class Game {
       { type: 'click', element: $reset, handler: this.reset },
       { type: 'click', element: $share, handler: this.share },
       { type: 'click', element: $swaps, handler: this.#deleteSwap },
+      { type: 'click', element: $undo, handler: this.#onUndo },
       { type: 'click', element: $words, handler: this.#deleteWord },
       { type: Grid.Events.Selection, handler: this.#updateSelection },
       { type: Grid.Events.Update, handler: this.#onGridUpdate }
@@ -110,6 +112,7 @@ export class Game {
     this.#updateWords()
     this.#updateStatistics()
     this.#updateSwaps()
+    this.#updateUndo()
   }
 
   #deleteSwap (event) {
@@ -139,6 +142,12 @@ export class Game {
     const state = this.#state.get()
     state.includeStateInShareUrl = event.target.checked
     this.#state.set(state)
+  }
+
+  #onUndo () {
+    if (!$undo.classList.contains(Game.ClassNames.Disabled)) {
+      this.#grid.undo()
+    }
   }
 
   #onWidthChange (event) {
@@ -216,6 +225,11 @@ export class Game {
     }))
   }
 
+  #updateUndo () {
+    const moves = this.#grid.getMoves()
+    $undo.classList.toggle(Game.ClassNames.Disabled, moves.length === 0)
+  }
+
   #updateWidthSelector () {
     $width.replaceChildren(...Grid.Widths.map((width) => {
       const $option = document.createElement('option')
@@ -277,6 +291,7 @@ export class Game {
   static ClassNames = Object.freeze({
     Container: 'container',
     Delete: 'delete',
+    Disabled: 'disabled',
     Expanded: 'expanded',
     FlexLeft: 'flex-left',
     FlexRight: 'flex-right',

--- a/src/index.html
+++ b/src/index.html
@@ -218,6 +218,7 @@
         </div>
         <div class="flex-right">
           <ul class="menu">
+            <li class="disabled" id="undo"><span class="material-symbols-outlined" title="Undo">undo</span></li>
             <li id="share"><span class="material-symbols-outlined" title="Share">share</span></li>
             <li id="reset"><span class="material-symbols-outlined" title="Reset">device_reset</span></li>
           </ul>

--- a/src/styles.css
+++ b/src/styles.css
@@ -568,21 +568,14 @@ p.center {
   background-color: #FDFFF7;
 }
 
-.grid .cell-swap::after,
 .grid .cell-swap .background,
-.grid .cell-swapped::after,
-.grid .cell-swapped .background {
+.grid .cell-swapped .background,
+.grid .cell-swapped.cell-validated .background {
   background-color: #B4ADEA;
 }
 
-.grid .cell-swapped.cell-selected::after,
 .grid .cell-swapped.cell-selected .background {
-  background-color: color-mix(in oklab, #B4ADEA, #FDFFF7)
-}
-
-.grid .cell-swapped.cell-validated::after,
-.grid .cell-swapped.cell-validated .background {
-  background-color: color-mix(in oklab, #B4ADEA, #59FFA0)
+  background-color: color-mix(in oklab, #B4ADEA 75%, #FDFFF7);
 }
 
 .grid .cell-validated::after,
@@ -591,6 +584,7 @@ p.center {
 }
 
 .grid .cell-path.cell-word-end::after {
+  background-color: black;
   opacity: 0.25;
 }
 
@@ -627,6 +621,11 @@ p.center {
   cursor: pointer;
   display: flex;
   padding: 1em;
+}
+
+.menu li.disabled {
+  color: #50514F;
+  cursor: default;
 }
 
 .menu a {


### PR DESCRIPTION
The implementation is basically a convenience for clicking the delete button next to a word or a swap in the drawer, whichever was done last. The delete buttons in the drawer will still work and will update the undo functionality accordingly.