### PR TITLE
Add list of hidden words to drawer. Fixes #24

### DIFF
--- a/src/components/grid.js
+++ b/src/components/grid.js
@@ -8,7 +8,7 @@ import {
   arrayEquals,
   arrayIncludes,
   cyrb53,
-  getClassName,
+  getClassName, getDateId,
   history,
   optionally, reverseString, sortNumerically,
   url,
@@ -791,14 +791,7 @@ export class Grid {
   static Name = 'grid'
   static ClassNames = Object.freeze({ Loading: getClassName(Grid.Name, 'loading') })
   static DateRegex = /^\d{4}-\d{2}-\d{2}$/
-  static DefaultId = (() => {
-    // The ID for the daily puzzle
-    const date = new Date()
-    const year = date.getFullYear()
-    const month = (date.getMonth() + 1).toString().padStart(2, '0')
-    const day = date.getDate().toString().padStart(2, '0')
-    return `${year}-${month}-${day}`
-  })()
+  static DefaultId = getDateId(new Date())
 
   static Events = Object.freeze({
     Selection: getClassName(Grid.Name, 'selection'),

--- a/src/components/util.js
+++ b/src/components/util.js
@@ -49,6 +49,13 @@ export function getClassName (...parts) {
   return parts.join('-')
 }
 
+export function getDateId (date) {
+  const year = date.getFullYear()
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 export function getIndexesUnique (rand, array, max) {
   const available = Object.keys(array)
   if (max > available.length) {

--- a/src/index.html
+++ b/src/index.html
@@ -330,6 +330,12 @@
             </li>
           </ul>
         </div>
+        <div class="section" id="hidden-words">
+          <details>
+            <summary id="hidden-words-title">Show Hidden Words (Spoiler)</summary>
+            <ul id="hidden-words-list"></ul>
+          </details>
+        </div>
       </div>
     </footer>
   </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -226,6 +226,17 @@ p.center {
   width: 100%;
 }
 
+#hidden-words-list {
+  list-style: inside decimal;
+}
+
+#hidden-words-list a {
+  color: #d2d3cd;
+  font-weight: normal;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
 #letter-points .letters {
   text-transform: uppercase;
 }
@@ -348,9 +359,11 @@ p.center {
 }
 
 .drawer h3,
-.drawer summary {
+.drawer summary,
+.drawer a {
   color: white;
   font-size: 1em;
+  font-weight: bold;
   margin: 0 0 0.5em 0;
 }
 


### PR DESCRIPTION
The words will be behind a `details` toggle and marked as "Spoiler". Users cannot see the words for the current day, only days in the past and on random puzzles.